### PR TITLE
add test sweepers for all resources (make sweep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## 1.2.0 (Unreleased)
 
-FEATURES:
-
-* Added test sweepers
-
 ## 1.1.0 (October 31, 2018)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.2.0 (Unreleased)
+
+FEATURES:
+
+* Added test sweepers
+
 ## 1.1.0 (October 31, 2018)
 
 FEATURES:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,8 +1,13 @@
+SWEEP?="tf_test,tf-test"
 TEST?=$$(go list ./... |grep -v 'vendor')
 TESTARGS?=$("-parallel=2","-timeout=120m")
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=linode
+
+sweep:
+	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
+	go test $(TEST) -v -sweep=$(SWEEP) $(SWEEPARGS)
 
 default: build
 
@@ -60,5 +65,5 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test
+.PHONY: build sweep test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test
 

--- a/linode/linode_sweeper_test.go
+++ b/linode/linode_sweeper_test.go
@@ -1,0 +1,49 @@
+package linode
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/linode/linodego"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func getClientForSweepers() (*linodego.Client, error) {
+	token := os.Getenv("LINODE_TOKEN")
+
+	if token == "" {
+		return nil, fmt.Errorf("LINODE_TOKEN must be set for acceptance tests")
+	}
+	client := getLinodeClient(token)
+	return &client, nil
+}
+
+func sweeperListOptions(prefix, field string) *linodego.ListOptions {
+	filterFmt := "{ %q : {\"+contains\": %q }}"
+
+	filter := fmt.Sprintf(filterFmt, field, prefix)
+	listOpts := linodego.NewListOptions(0, filter)
+	return listOpts
+}
+
+func shouldSweepAcceptanceTestResource(prefix, name string) bool {
+	loweredName := strings.ToLower(name)
+	if len(prefix) < 3 {
+		log.Printf("Ignoring Resource %q because sweeper prefix is too short %q", name, prefix)
+		return false
+	}
+
+	if !strings.HasPrefix(loweredName, prefix) && !strings.HasPrefix(loweredName, "renamed-"+prefix) {
+		log.Printf("Ignoring Resource %q as it doesn't start with `(renamed-)?%s`", name, prefix)
+		return false
+	}
+
+	return true
+}

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -58,6 +58,18 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if !ok {
 		return nil, fmt.Errorf("The Linode API Token was not valid")
 	}
+
+	client := getLinodeClient(token)
+	// Ping the API for an empty response to verify the configuration works
+	_, err := client.ListTypes(context.Background(), linodego.NewListOptions(100, ""))
+	if err != nil {
+		return nil, fmt.Errorf("Error connecting to the Linode API: %s", err)
+	}
+
+	return client, nil
+}
+
+func getLinodeClient(token string) linodego.Client {
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 
 	oauthTransport := &oauth2.Transport{
@@ -75,12 +87,5 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		version.String(), projectURL, linodego.Version)
 
 	client.SetUserAgent(userAgent)
-
-	// Ping the API for an empty response to verify the configuration works
-	_, err := client.ListTypes(context.Background(), linodego.NewListOptions(100, ""))
-	if err != nil {
-		return nil, fmt.Errorf("Error connecting to the Linode API: %s", err)
-	}
-
-	return client, nil
+	return client
 }

--- a/linode/resource_linode_image_test.go
+++ b/linode/resource_linode_image_test.go
@@ -11,6 +11,39 @@ import (
 	"github.com/linode/linodego"
 )
 
+func init() {
+	resource.AddTestSweepers("linode_image", &resource.Sweeper{
+		Name: "linode_image",
+		F:    testSweepLinodeImage,
+	})
+
+}
+
+func testSweepLinodeImage(prefix string) error {
+	client, err := getClientForSweepers()
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+
+	listOpts := sweeperListOptions(prefix, "label")
+	images, err := client.ListImages(context.Background(), listOpts)
+	if err != nil {
+		return fmt.Errorf("Error getting images: %s", err)
+	}
+	for _, image := range images {
+		if !shouldSweepAcceptanceTestResource(prefix, image.Label) {
+			continue
+		}
+		err := client.DeleteImage(context.Background(), image.ID)
+
+		if err != nil {
+			return fmt.Errorf("Error destroying %s during sweep: %s", image.Label, err)
+		}
+	}
+
+	return nil
+}
+
 func TestAccLinodeImage_basic(t *testing.T) {
 	t.Parallel()
 

--- a/linode/resource_linode_instance_test.go
+++ b/linode/resource_linode_instance_test.go
@@ -13,6 +13,38 @@ import (
 	"github.com/linode/linodego"
 )
 
+func init() {
+	resource.AddTestSweepers("linode_instance", &resource.Sweeper{
+		Name: "linode_instance",
+		F:    testSweepLinodeInstance,
+	})
+}
+
+func testSweepLinodeInstance(prefix string) error {
+	client, err := getClientForSweepers()
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+
+	listOpts := sweeperListOptions(prefix, "label")
+	instances, err := client.ListInstances(context.Background(), listOpts)
+	if err != nil {
+		return fmt.Errorf("Error getting instances: %s", err)
+	}
+	for _, instance := range instances {
+		if !shouldSweepAcceptanceTestResource(prefix, instance.Label) {
+			continue
+		}
+		err := client.DeleteInstance(context.Background(), instance.ID)
+
+		if err != nil {
+			return fmt.Errorf("Error destroying %s during sweep: %s", instance.Label, err)
+		}
+	}
+
+	return nil
+}
+
 func TestAccLinodeInstance_basic(t *testing.T) {
 	t.Parallel()
 

--- a/linode/resource_linode_sshkey_test.go
+++ b/linode/resource_linode_sshkey_test.go
@@ -12,6 +12,38 @@ import (
 	"github.com/linode/linodego"
 )
 
+func init() {
+	resource.AddTestSweepers("linode_sshkey", &resource.Sweeper{
+		Name: "linode_sshkey",
+		F:    testSweepLinodeSSHKey,
+	})
+}
+
+func testSweepLinodeSSHKey(prefix string) error {
+	client, err := getClientForSweepers()
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+
+	listOpts := sweeperListOptions(prefix, "label")
+	sshkeys, err := client.ListSSHKeys(context.Background(), listOpts)
+	if err != nil {
+		return fmt.Errorf("Error getting sshkeys: %s", err)
+	}
+	for _, sshkey := range sshkeys {
+		if !shouldSweepAcceptanceTestResource(prefix, sshkey.Label) {
+			continue
+		}
+		err := client.DeleteSSHKey(context.Background(), sshkey.ID)
+
+		if err != nil {
+			return fmt.Errorf("Error destroying %s during sweep: %s", sshkey.Label, err)
+		}
+	}
+
+	return nil
+}
+
 func TestAccLinodeSSHKey_basic(t *testing.T) {
 	t.Parallel()
 

--- a/linode/resource_linode_stackscript_test.go
+++ b/linode/resource_linode_stackscript_test.go
@@ -12,6 +12,38 @@ import (
 	"github.com/linode/linodego"
 )
 
+func init() {
+	resource.AddTestSweepers("linode_stackscript", &resource.Sweeper{
+		Name: "linode_stackscript",
+		F:    testSweepLinodeStackScript,
+	})
+}
+
+func testSweepLinodeStackScript(prefix string) error {
+	client, err := getClientForSweepers()
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+
+	listOpts := sweeperListOptions(prefix, "label")
+	stackscripts, err := client.ListStackscripts(context.Background(), listOpts)
+	if err != nil {
+		return fmt.Errorf("Error getting stackscripts: %s", err)
+	}
+	for _, stackscript := range stackscripts {
+		if !shouldSweepAcceptanceTestResource(prefix, stackscript.Label) {
+			continue
+		}
+		err := client.DeleteStackscript(context.Background(), stackscript.ID)
+
+		if err != nil {
+			return fmt.Errorf("Error destroying %s during sweep: %s", stackscript.Label, err)
+		}
+	}
+
+	return nil
+}
+
 func TestAccLinodeStackscript_basic(t *testing.T) {
 	t.Parallel()
 

--- a/linode/resource_linode_template_test.go
+++ b/linode/resource_linode_template_test.go
@@ -14,6 +14,38 @@ import (
 	"github.com/linode/linodego"
 )
 
+func init() {
+	resource.AddTestSweepers("linode_template", &resource.Sweeper{
+		Name: "linode_template",
+		F:    testSweepLinodeTemplate,
+	})
+}
+
+func testSweepLinodeTemplate(prefix string) error {
+	client, err := getClientForSweepers()
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+
+	listOpts := sweeperListOptions(prefix, "label")
+	templates, err := client.ListTemplates(context.Background(), listOpts)
+	if err != nil {
+		return fmt.Errorf("Error getting templates: %s", err)
+	}
+	for _, template := range templates {
+		if !shouldSweepAcceptanceTestResource(prefix, template.Label) {
+			continue
+		}
+		err := client.DeleteTemplate(context.Background(), template.ID)
+
+		if err != nil {
+			return fmt.Errorf("Error destroying %s during sweep: %s", template.Label, err)
+		}
+	}
+
+	return nil
+}
+
 func TestAccLinodeTemplate_basic(t *testing.T) {
 	t.Parallel()
 

--- a/linode/resource_linode_token_test.go
+++ b/linode/resource_linode_token_test.go
@@ -12,6 +12,38 @@ import (
 	"github.com/linode/linodego"
 )
 
+func init() {
+	resource.AddTestSweepers("linode_token", &resource.Sweeper{
+		Name: "linode_token",
+		F:    testSweepLinodeToken,
+	})
+}
+
+func testSweepLinodeToken(prefix string) error {
+	client, err := getClientForSweepers()
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+
+	listOpts := sweeperListOptions(prefix, "label")
+	tokens, err := client.ListTokens(context.Background(), listOpts)
+	if err != nil {
+		return fmt.Errorf("Error getting tokens: %s", err)
+	}
+	for _, token := range tokens {
+		if !shouldSweepAcceptanceTestResource(prefix, token.Label) {
+			continue
+		}
+		err := client.DeleteToken(context.Background(), token.ID)
+
+		if err != nil {
+			return fmt.Errorf("Error destroying %s during sweep: %s", token.Label, err)
+		}
+	}
+
+	return nil
+}
+
 func TestAccLinodeToken_basic(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`make sweep` will now remove any of the following resources that are labeled "tf_test" or "tf-test" (optionally pre-prefixed by "renamed-"):
- instances
- volumes
- nodebalancers
- images
- stackscripts
- sshkey
- domains (domains don't allow "_", thus the "tf-test" filter)

This will remove any residual artifacts from the acceptance tests.