### PR TITLE
add support for linode_instance tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.2.0 (Unreleased)
 
+ENHANCEMENTS:
+
+* resource/linode_instance: Add `tags` field
+
 ## 1.1.0 (October 31, 2018)
 
 FEATURES:

--- a/linode/resource_linode_instance_test.go
+++ b/linode/resource_linode_instance_test.go
@@ -725,6 +725,40 @@ func TestAccLinodeInstance_diskRawResize(t *testing.T) {
 	})
 }
 
+func TestAccLinodeInstance_tag(t *testing.T) {
+	t.Parallel()
+	var instance linodego.Instance
+	var instanceName = acctest.RandomWithPrefix("tf_test")
+	resName := "linode_instance.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLinodeInstanceDestroy,
+		Steps: []resource.TestStep{
+			// Start off with a single tag
+			resource.TestStep{
+				Config: testAccCheckLinodeInstanceWithTag(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resName, "tags.0", "tf_test"),
+				),
+			},
+			// Apply updated tags
+			resource.TestStep{
+				Config: testAccCheckLinodeInstanceWithUpdatedTag(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resName, "tags.0", "tf_test"),
+					resource.TestCheckResourceAttr(resName, "tags.1", "tf_test_2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLinodeInstance_diskRawDeleted(t *testing.T) {
 	t.Parallel()
 	var instance linodego.Instance
@@ -1367,6 +1401,34 @@ resource "linode_instance" "foobar" {
 	group = "tf_test"
 	type = "g6-nanode-1"
 	region = "us-east"
+}`, instance)
+}
+
+func testAccCheckLinodeInstanceWithTag(instance string) string {
+	return fmt.Sprintf(`
+resource "linode_instance" "foobar" {
+	label = "%s"
+	tags = ["tf_test"]
+	type = "g6-nanode-1"
+	region = "us-east"
+	config {
+		label = "config"
+		kernel = "linode/latest-64bit"
+	}
+}`, instance)
+}
+
+func testAccCheckLinodeInstanceWithUpdatedTag(instance string) string {
+	return fmt.Sprintf(`
+resource "linode_instance" "foobar" {
+	label = "%s"
+	tags = ["tf_test", "tf_test_2"]
+	type = "g6-nanode-1"
+	region = "us-east"
+	config {
+		label = "config"
+		kernel = "linode/latest-64bit"
+	}
 }`, instance)
 }
 

--- a/website/docs/r/instance.html.md
+++ b/website/docs/r/instance.html.md
@@ -15,7 +15,7 @@ Linode Instances can also use [provisioners](/docs/provisioners/index.html).
 
 ## Example Usage
 
-### Simple Linode Instance Style
+### Simple Linode Instance
 
 The following example shows how one might use this resource to configure a Linode instance.
 
@@ -29,6 +29,7 @@ resource "linode_instance" "web" {
     root_pass = "terr4form-test"
 
     group = "foo"
+    tags = [ "foo" ]
     swap_size = 256
     private_ip = true
 }
@@ -42,6 +43,7 @@ Using explicit Instance Configs and Disks it is possible to create a more elabor
 resource "linode_instance" "web" {
   label      = "complex_instance"
   group      = "foo"
+  tags = [ "foo" ]
   region     = "us-central"
   type       = "g6-nanode-1"
   private_ip = true
@@ -61,6 +63,7 @@ resource "linode_instance" "web" {
       sda = { disk_label = "boot" },
       sdb = { volume_id = "${linode_volume.web_volume.id}" }
     }
+    root_device = "/dev/sda"
   }
 
   boot_config_label = "boot_config"
@@ -84,6 +87,8 @@ The following arguments are supported:
 * `label` - (Optional) The Linode's label is for display purposes only. If no label is provided for a Linode, a default will be assigned.
 
 * `group` - (Optional) The display group of the Linode instance.
+
+* `tags` - (Optional) A list of tags applied to this object. Tags are for organizational purposes only.
 
 * `private_ip` - (Optional) If true, the created Linode will have private networking enabled, allowing use of the 192.168.128.0/17 network within the Linode's region. It can be enabled on an existing Linode but it can't be disabled.
 
@@ -228,3 +233,9 @@ Linodes Instances can be imported using the Linode `id`, e.g.
 ```sh
 terraform import linode_instance.mylinode 1234567
 ```
+
+When importing an instance, all `disk` and `config` values must be represented.
+
+Imported disks must include their `label` value.  **Any disk that is not precisely represented may be removed resulting in data loss.**
+
+Imported configs should include all `devices`, and must include `label`, `kernel`, and the `root_device`.  The instance must include a `boot_config_label` referring to the correct configuration profile.


### PR DESCRIPTION
This PR adds support for `linode_instance` tags. 

```md
ENHANCEMENTS:

* resource/linode_instance: Add `tags` field
```

```hcl
 resource "linode_instance" "web" {
    ...
    tags = [ "foo" ]
}
```
