### PR TITLE
add support for timeouts on instance, image, and volume resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## 1.2.1 (Unreleased)
+
+ENHANCEMENTS:
+
+* resource/linode\_instance: Add `timeouts` support for `create`, `update`, and `delete` (defaults 10, 20, 10)
+* resource/linode\_image: Add `timeouts` support for `create` (defaults 20)
+* resource/linode\_volume: Add `timeouts` support for `create`, `update`, and `delete` (defaults 10, 20, 10)
+
 ## 1.2.0 (November 08, 2018)
 
 ENHANCEMENTS:

--- a/linode/linode_instance_helpers.go
+++ b/linode/linode_instance_helpers.go
@@ -461,7 +461,7 @@ func makeVolumeDetacher(client linodego.Client, d *schema.ResourceData) volumeDe
 		}
 
 		log.Printf("[INFO] Waiting for Linode Volume %d to detach ...", volumeID)
-		if _, err := client.WaitForVolumeLinodeID(ctx, volumeID, nil, int(d.Timeout("update").Seconds())); err != nil {
+		if _, err := client.WaitForVolumeLinodeID(ctx, volumeID, nil, int(d.Timeout(schema.TimeoutUpdate).Seconds())); err != nil {
 			return err
 		}
 		return nil

--- a/linode/resource_linode_image.go
+++ b/linode/resource_linode_image.go
@@ -10,6 +10,10 @@ import (
 	"github.com/linode/linodego"
 )
 
+const (
+	LinodeImageCreateTimeout = 20 * time.Minute
+)
+
 func resourceLinodeImage() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceLinodeImageCreate,
@@ -19,6 +23,9 @@ func resourceLinodeImage() *schema.Resource {
 		Exists: resourceLinodeImageExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(LinodeImageCreateTimeout),
 		},
 		Schema: map[string]*schema.Schema{
 			"label": {
@@ -144,7 +151,7 @@ func resourceLinodeImageCreate(d *schema.ResourceData, meta interface{}) error {
 	linodeID := d.Get("linode_id").(int)
 	diskID := d.Get("disk_id").(int)
 
-	if _, err := client.WaitForInstanceDiskStatus(context.Background(), linodeID, diskID, linodego.DiskReady, int(d.Timeout("create").Seconds())); err != nil {
+	if _, err := client.WaitForInstanceDiskStatus(context.Background(), linodeID, diskID, linodego.DiskReady, int(d.Timeout(schema.TimeoutCreate).Seconds())); err != nil {
 		return fmt.Errorf("Error waiting for Linode Instance %d Disk %d to become ready for taking an Image", linodeID, diskID)
 	}
 
@@ -164,7 +171,7 @@ func resourceLinodeImageCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetPartial("description")
 	d.Partial(false)
 
-	if _, err := client.WaitForInstanceDiskStatus(context.Background(), linodeID, diskID, linodego.DiskReady, int(d.Timeout("create").Seconds())); err != nil {
+	if _, err := client.WaitForInstanceDiskStatus(context.Background(), linodeID, diskID, linodego.DiskReady, int(d.Timeout(schema.TimeoutCreate).Seconds())); err != nil {
 		return fmt.Errorf("Error waiting for Linode Instance %d Disk %d to become ready while taking an Image", linodeID, diskID)
 	}
 

--- a/linode/resource_linode_instance.go
+++ b/linode/resource_linode_instance.go
@@ -12,6 +12,12 @@ import (
 	"github.com/linode/linodego"
 )
 
+const (
+	LinodeInstanceCreateTimeout = 10 * time.Minute
+	LinodeInstanceUpdateTimeout = 20 * time.Minute
+	LinodeInstanceDeleteTimeout = 10 * time.Minute
+)
+
 func resourceLinodeInstance() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceLinodeInstanceCreate,
@@ -19,9 +25,13 @@ func resourceLinodeInstance() *schema.Resource {
 		Update: resourceLinodeInstanceUpdate,
 		Delete: resourceLinodeInstanceDelete,
 		Exists: resourceLinodeInstanceExists,
-
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(LinodeInstanceCreateTimeout),
+			Update: schema.DefaultTimeout(LinodeInstanceUpdateTimeout),
+			Delete: schema.DefaultTimeout(LinodeInstanceDeleteTimeout),
 		},
 		Schema: map[string]*schema.Schema{
 			"image": &schema.Schema{

--- a/website/docs/r/image.html.md
+++ b/website/docs/r/image.html.md
@@ -44,6 +44,12 @@ The following arguments are supported:
 
 * `description` - (Optional) A detailed description of this Image.
 
+### Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 20 mins) Used when creating the instance image (until the instance is available)
+
 ## Attributes
 
 This resource exports the following attributes:

--- a/website/docs/r/instance.html.md
+++ b/website/docs/r/instance.html.md
@@ -204,6 +204,14 @@ Configuration profiles define the VM settings and boot behavior of the Linode In
 
     * `memory_limit` - (Optional) - Defaults to the total RAM of the Linode
 
+### Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 10 mins) Used when launching the instance (until it reaches the initial `running` state)
+* `update` - (Defaults to 20 mins) Used when stopping and starting the instance when necessary during update - e.g. when changing instance type
+* `delete` - (Defaults to 10 mins) Used when terminating the instance
+
 ## Attributes
 
 This Linode Instance resource exports the following attributes:

--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -60,6 +60,14 @@ The following arguments are supported:
 
 * `linode_id` - (Optional) The ID of a Linode Instance where the the Volume should be attached.
 
+### Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 10 mins) Used when creating the volume (until the volume is reaches the initial `active` state)
+* `update` - (Defaults to 20 mins) Used when updating the volume when necessary during update - e.g. when resizing the volume
+* `delete` - (Defaults to 10 mins) Used when deleting the volume
+
 ## Attributes
 
 This resource exports the following attributes:


### PR DESCRIPTION
It is not possible to override `timeouts` on a resource, unless that resource supports `timeouts`.

This PR adds some default timeout values to resources that interact with disks, node, and job scheduling which can take longer periods of time based on size and demand.

* `resource/linode_instance`: Add `timeouts` support for `create`, `update`, and `delete` (defaults 10, 20, 10)
* `resource/linode_image`: Add `timeouts` support for `create` (defaults 20)
* `resource/linode_volume`: Add `timeouts` support for `create`, `update`, and `delete` (defaults 10, 20, 10)

https://www.terraform.io/docs/configuration/resources.html#timeouts

```hcl
resource "linode_instance" "foo" {
    ...
    timeouts {
        create = "10m"
        update = "20m"
        delete = "10m"
    }
}

resource "linode_image" "foo" {
    ...
    timeouts {
        create = "10m"
    }
}

resource "linode_volume" "foo" {
    ...
    timeouts {
        create = "10m"
        update = "20m"
        delete = "10m"
    }
}
```