### PR TITLE
[NEW] Add a domain data source

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -16,6 +16,10 @@ data "linode_image" "ubuntu" {
   id = "linode/ubuntu18.04"
 }
 
+data "linode_domain" "linode_com" {
+  id = "1234566"
+}
+
 resource "linode_nodebalancer" "foo-nb" {
   label                = "${random_pet.project.id}"
   region               = "${data.linode_region.main.id}"

--- a/linode/data_source_linode_domain.go
+++ b/linode/data_source_linode_domain.go
@@ -1,0 +1,138 @@
+package linode
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/linode/linodego"
+)
+
+func dataSourceLinodeDomain() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceLinodeDomainRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"domain": {
+				Type:        schema.TypeString,
+				Description: "The domain this Domain represents. These must be unique in our system; you cannot have two Domains representing the same domain.",
+				Computed:    true,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Description: "If this Domain represents the authoritative source of information for the domain it describes, or if it is a read-only copy of a master (also called a slave).",
+				Computed:    true,
+			},
+			"group": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The group this Domain belongs to. This is for display purposes only.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Used to control whether this Domain is currently being rendered.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A description for this Domain. This is for display purposes only.",
+			},
+			"master_ips": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "The IP addresses representing the master DNS for this Domain.",
+				Computed:    true,
+			},
+			"axfr_ips": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "The list of IPs that may perform a zone transfer for this Domain. This is potentially dangerous, and should be set to an empty list unless you intend to use it.",
+				Computed:    true,
+			},
+			"ttl_sec": {
+				Type:        schema.TypeInt,
+				Description: "'Time to Live' - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
+				Computed:    true,
+			},
+			"retry_sec": {
+				Type:        schema.TypeInt,
+				Description: "The interval, in seconds, at which a failed refresh should be retried. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
+				Computed:    true,
+			},
+			"expire_sec": {
+				Type:        schema.TypeInt,
+				Description: "The amount of time in seconds that may pass before this Domain is no longer authoritative. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
+				Computed:    true,
+			},
+			"refresh_sec": {
+				Type:        schema.TypeInt,
+				Description: "The amount of time in seconds before this Domain should be refreshed. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
+				Computed:    true,
+			},
+			"soa_email": {
+				Type:        schema.TypeString,
+				Description: "Start of Authority email address. This is required for master Domains.",
+				Computed:    true,
+			},
+			"tags": {
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "An array of tags applied to this object. Tags are for organizational purposes only.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceLinodeDomainRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(linodego.Client)
+
+	reqDomain := d.Get("id").(string)
+
+	if reqDomain == "" {
+		return fmt.Errorf("Domain id is required")
+	}
+
+	reqDomainInt, err := strconv.Atoi(reqDomain)
+
+	if err != nil {
+		return fmt.Errorf("Domain id number be a valid integer")
+	}
+
+	domain, err := client.GetDomain(context.Background(), reqDomainInt)
+	if err != nil {
+		return fmt.Errorf("Error listing domain: %s", err)
+	}
+
+	if domain != nil {
+		d.SetId(strconv.Itoa(domain.ID))
+		d.Set("domain", domain.Domain)
+		d.Set("type", domain.Type)
+		d.Set("group", domain.Group)
+		d.Set("status", domain.Status)
+		d.Set("description", domain.Description)
+		d.Set("master_ips", domain.MasterIPs)
+		d.Set("axfr_ips", domain.AXfrIPs)
+		d.Set("ttl_sec", domain.TTLSec)
+		d.Set("retry_sec", domain.RetrySec)
+		d.Set("expire_sec", domain.ExpireSec)
+		d.Set("refresh_sec", domain.RefreshSec)
+		d.Set("soa_email", domain.SOAEmail)
+		d.Set("tags", domain.Tags)
+		return nil
+	}
+
+	d.SetId("")
+
+	return fmt.Errorf("Domain %s was not found", reqDomain)
+}

--- a/linode/data_source_linode_domain_test.go
+++ b/linode/data_source_linode_domain_test.go
@@ -1,0 +1,35 @@
+package linode
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceLinodeDomain(t *testing.T) {
+	t.Parallel()
+
+	domainID := "1234567"
+	resourceName := "data.linode_domain.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceLinodeDomain(domainID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", domainID),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceLinodeDomain(domainID string) string {
+	return fmt.Sprintf(`
+data "linode_domain" "foobar" {
+	id = "%s"
+}`, domainID)
+}

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -27,6 +27,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"linode_account":       dataSourceLinodeAccount(),
+			"linode_domain":        dataSourceLinodeDomain(),
 			"linode_instance_type": dataSourceLinodeInstanceType(),
 			"linode_region":        dataSourceLinodeRegion(),
 			"linode_image":         dataSourceLinodeImage(),

--- a/website/docs/d/domain.html.md
+++ b/website/docs/d/domain.html.md
@@ -1,0 +1,57 @@
+---
+layout: "linode"
+page_title: "Linode: linode_domain"
+sidebar_current: "docs-linode-datasource-domain"
+description: |-
+  Provides details about a Linode domain.
+---
+
+# Data Source: linode\_domain
+
+Provides information about a Linode domain.
+
+## Example Usage
+
+The following example shows how one might use this data source to access information about a Linode domain.
+
+```hcl
+data "linode_domain" "linode_com" {
+    id = "1234567"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - (Required) The unique ID of this Domain.
+
+## Attributes
+
+The Linode Domain resource exports the following attributes:
+
+* `domain` - The domain this Domain represents. These must be unique in our system; you cannot have two Domains representing the same domain
+
+* `type` - If this Domain represents the authoritative source of information for the domain it describes, or if it is a read-only copy of a master (also called a slave)
+
+* `group` - The group this Domain belongs to.
+
+* `status` - Used to control whether this Domain is currently being rendered.
+
+* `description` - A description for this Domain.
+
+* `master_ips` - The IP addresses representing the master DNS for this Domain.
+
+* `axfr_ips` - The list of IPs that may perform a zone transfer for this Domain.
+
+* `ttl_sec` - 'Time to Live'-the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers.
+
+* `retry_sec` - The interval, in seconds, at which a failed refresh should be retried.
+*
+* `expire_sec` - The amount of time in seconds that may pass before this Domain is no longer authoritative.
+
+* `refresh_sec` - The amount of time in seconds before this Domain should be refreshed.
+
+* `soa_email` - Start of Authority email address.
+
+* `tags` - An array of tags applied to this object.

--- a/website/docs/r/instance.html.md
+++ b/website/docs/r/instance.html.md
@@ -49,7 +49,7 @@ resource "linode_instance" "web" {
   region     = "us-central"
   type       = "g6-nanode-1"
   private_ip = true
-  
+
   disk {
     label = "boot"
     size = 3000
@@ -139,13 +139,13 @@ By specifying the `disk` and `config` fields for a Linode instance, it is possib
 * `boot_config_label` - (Optional) The Label of the Instance Config that should be used to boot the Linode instance.  If there is only one `config`, the `label` of that `config` will be used as the `boot_config_label`. *This value can not be imported.*
 
 #### Disks
-  
+
 * `disk`
 
   * `label` - (Required) The disks label, which acts as an identifier in Terraform.  This must be unique within each Linode Instance.
 
   * `size` - (Required) The size of the Disk in MB.
-  
+
   * `id` - (Computed) The ID of the disk in the Linode API.
 
   * `filesystem` - (Optional) The Disk filesystem can be one of: `"raw"`, `"swap"`, `"ext3"`, `"ext4"`, or `"initrd"` which has a max size of 32mb and can be used in the config `initrd` (not currently supported in this Terraform Provider).


### PR DESCRIPTION
This add a new domain data source to access details about a domain from the API. 

This is my first foray into Go, so I might have messed up the [integer conversions](https://github.com/terraform-providers/terraform-provider-linode/pull/26/files#diff-7c8f040ebdf5de9108e879df8e1e0ae5R118).

Also, this is almost a direct copy-paste from the `data.linode_instance` source... I think I got all the references to "image" but you might want to make sure I didn't mess anything else up.

If this is satisfactory, but needs a small tweak, by all means, feel free to add commits.