### PR TITLE
Add missing required argument to example

### DIFF
--- a/website/docs/r/domain.html.md
+++ b/website/docs/r/domain.html.md
@@ -21,6 +21,7 @@ The following example shows how one might use this resource to configure a Domai
 resource "linode_domain" "foobar" {
     domain = "foobar.example"
     soa_email = "example@foobar.example"
+    type = "master"
     tags = ["foo", "bar"]
 }
 


### PR DESCRIPTION
Started using this provider today and noticed that the domain resource example in the docs didn't work as it's missing the required `type` field.

Added this to the example with the value `master`.