### PR TITLE
add missing type param for linode_domain

### DIFF
--- a/website/docs/r/domain.html.md
+++ b/website/docs/r/domain.html.md
@@ -19,6 +19,7 @@ The following example shows how one might use this resource to configure a Domai
 
 ```hcl
 resource "linode_domain" "foobar" {
+    type = "master"
     domain = "foobar.example"
     soa_email = "example@foobar.example"
     type = "master"

--- a/website/docs/r/domain_record.html.md
+++ b/website/docs/r/domain_record.html.md
@@ -17,6 +17,7 @@ The following example shows how one might use this resource to configure a Domai
 
 ```hcl
 resource "linode_domain" "foobar" {
+    type = "master"
     domain = "foobar.example"
     soa_email = "example@foobar.example"
 }


### PR DESCRIPTION
Documentation for `linode_domain` is missing the `type` parameter, which is required.

Relates to https://github.com/terraform-providers/terraform-provider-linode/pull/34