### PR TITLE
add linode_rdns resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ FEATURES:
 
 * **New Resource** `linode_rdns`
 
+* **New Data Resource** `linode_network_ip`
+
 ENHANCEMENTS:
 
 * Builds now use `go mod`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 ## 1.6.0 (Unreleased)
+
+FEATURES:
+
+* **New Resource** `linode_rdns`
+
+ENHANCEMENTS:
+
+* Builds now use `go mod`
+
+BUG FIXES:
+
+* Documentation and examples for `linode_domain` resource were missing required `type` field
+
 ## 1.5.0 (February 06, 2019)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ FEATURES:
 
 * **New Resource** `linode_rdns`
 
-* **New Data Resource** `linode_network_ip`
+* **New Data Resource** `linode_networking_ip`
 
 ENHANCEMENTS:
 
 * Builds now use `go mod`
+* provider: Support custom `ua_prefix`
+* provider: Support custom API endpoint `url`
 
 BUG FIXES:
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -241,3 +241,11 @@ resource "linode_instance" "simple" {
     "package" = "nginx"
   }
 }
+
+data "linode_networking_ip" "simple_v4" {
+  address = "${linode_instance.simple.ip_address}"
+}
+
+data "linode_networking_ip" "simple_v6" {
+  address = "${replace(linode_instance.simple.ipv6, "/64", "")}"
+}

--- a/examples/outputs.tf
+++ b/examples/outputs.tf
@@ -17,3 +17,11 @@ output "Nginx Cluster" {
 output "Nginx Lonewolf" {
   value = "${linode_instance.simple.*.ip_address}"
 }
+
+output "Simple-IPv4" {
+  value = "${data.linode_networking_ip.simple_v4.address}/${data.linode_networking_ip.simple_v4.prefix} (${data.linode_networking_ip.simple_v4.rdns})"
+}
+
+output "Simple-IPv6" {
+  value = "${data.linode_networking_ip.simple_v6.address}/${data.linode_networking_ip.simple_v6.prefix} (${data.linode_networking_ip.simple_v6.rdns})"
+}

--- a/linode/data_source_linode_networking_ip.go
+++ b/linode/data_source_linode_networking_ip.go
@@ -1,0 +1,96 @@
+package linode
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/linode/linodego"
+)
+
+func dataSourceLinodeNetworkingIP() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceLinodeNetworkingIPRead,
+
+		Schema: map[string]*schema.Schema{
+			"address": {
+				Type:        schema.TypeString,
+				Description: "The IP address.",
+				Required:    true,
+			},
+			"gateway": {
+				Type:        schema.TypeString,
+				Description: "The default gateway for this address.",
+				Computed:    true,
+			},
+			"subnet_mask": {
+				Type:        schema.TypeString,
+				Description: "The mask that separates host bits from network bits for this address.",
+				Computed:    true,
+			},
+			"prefix": {
+				Type:        schema.TypeInt,
+				Description: "The number of bits set in the subnet mask.",
+				Computed:    true,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Description: "The type of address this is (ipv4, ipv6, ipv6/pool, ipv6/range).",
+				Computed:    true,
+			},
+			"public": {
+				Type:        schema.TypeBool,
+				Description: "Whether this is a public or private IP address.",
+				Computed:    true,
+			},
+			"rdns": {
+				Type:        schema.TypeString,
+				Description: "The reverse DNS assigned to this address. For public IPv4 addresses, this will be set to a default value provided by Linode if not explicitly set.",
+				Computed:    true,
+			},
+			"linode_id": {
+				Type:        schema.TypeInt,
+				Description: "The ID of the Linode this address currently belongs to.",
+				Computed:    true,
+			},
+			"region": {
+				Type:        schema.TypeString,
+				Description: "The Region this IP address resides in.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceLinodeNetworkingIPRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(linodego.Client)
+
+	reqImage := d.Get("address").(string)
+
+	if reqImage == "" {
+		return fmt.Errorf("NetworkingIP address is required")
+	}
+
+	address, err := client.GetIPAddress(context.Background(), reqImage)
+	if err != nil {
+		return fmt.Errorf("Error listing addresses: %s", err)
+	}
+
+	if address != nil {
+		d.SetId(address.Address)
+		d.Set("address", address.Address)
+		d.Set("gateway", address.Gateway)
+		d.Set("subnet_mask", address.SubnetMask)
+		d.Set("prefix", address.Prefix)
+		d.Set("type", address.Type)
+		d.Set("public", address.Public)
+		d.Set("rdns", address.RDNS)
+		d.Set("linode_id", address.LinodeID)
+		d.Set("region", address.Region)
+		return nil
+	}
+
+	d.SetId("")
+
+	return fmt.Errorf("NetworkingIP address %s was not found", reqImage)
+}

--- a/linode/data_source_linode_networking_ip_test.go
+++ b/linode/data_source_linode_networking_ip_test.go
@@ -1,0 +1,57 @@
+package linode
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceLinodeNetworkingIP(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "linode_instance.foobar"
+	dataResourceName := "data.linode_networking_ip.foobar"
+
+	label := acctest.RandomWithPrefix("tf-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceLinodeNetworkingIP(label),
+			},
+			{
+				Config: testDataSourceLinodeNetworkingIP(label),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataResourceName, "address", resourceName, "ip_address"),
+					resource.TestCheckResourceAttrPair(dataResourceName, "linode_id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataResourceName, "region", resourceName, "region"),
+					resource.TestMatchResourceAttr(dataResourceName, "gateway", regexp.MustCompile(`\.1$`)),
+					resource.TestCheckResourceAttr(dataResourceName, "type", "ipv4"),
+					resource.TestCheckResourceAttr(dataResourceName, "public", "true"),
+					resource.TestCheckResourceAttr(dataResourceName, "prefix", "24"),
+					resource.TestMatchResourceAttr(dataResourceName, "rdns", regexp.MustCompile(`\.members\.linode\.com$`)),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceLinodeNetworkingIP(label string) string {
+	return fmt.Sprintf(`
+resource "linode_instance" "foobar" {
+	label = "%s"
+	group = "tf_test"
+	image = "linode/containerlinux"
+	type = "g6-standard-1"
+	region = "us-east"
+}
+
+data "linode_networking_ip" "foobar" {
+	address = "${linode_instance.foobar.ip_address}"
+}`, label)
+}

--- a/linode/linode_sweeper_test.go
+++ b/linode/linode_sweeper_test.go
@@ -21,7 +21,7 @@ func getClientForSweepers() (*linodego.Client, error) {
 	if token == "" {
 		return nil, fmt.Errorf("LINODE_TOKEN must be set for acceptance tests")
 	}
-	client := getLinodeClient(token)
+	client := getLinodeClient(token, "", "")
 	return &client, nil
 }
 

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -30,6 +30,7 @@ func Provider() terraform.ResourceProvider {
 			"linode_domain":        dataSourceLinodeDomain(),
 			"linode_image":         dataSourceLinodeImage(),
 			"linode_instance_type": dataSourceLinodeInstanceType(),
+			"linode_networking_ip": dataSourceLinodeNetworkingIP(),
 			"linode_profile":       dataSourceLinodeProfile(),
 			"linode_region":        dataSourceLinodeRegion(),
 			"linode_sshkey":        dataSourceLinodeSSHKey(),

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -28,11 +28,11 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"linode_account":       dataSourceLinodeAccount(),
 			"linode_domain":        dataSourceLinodeDomain(),
-			"linode_instance_type": dataSourceLinodeInstanceType(),
-			"linode_region":        dataSourceLinodeRegion(),
 			"linode_image":         dataSourceLinodeImage(),
-			"linode_sshkey":        dataSourceLinodeSSHKey(),
+			"linode_instance_type": dataSourceLinodeInstanceType(),
 			"linode_profile":       dataSourceLinodeProfile(),
+			"linode_region":        dataSourceLinodeRegion(),
+			"linode_sshkey":        dataSourceLinodeSSHKey(),
 			"linode_user":          dataSourceLinodeUser(),
 		},
 
@@ -44,10 +44,11 @@ func Provider() terraform.ResourceProvider {
 			"linode_nodebalancer":        resourceLinodeNodeBalancer(),
 			"linode_nodebalancer_config": resourceLinodeNodeBalancerConfig(),
 			"linode_nodebalancer_node":   resourceLinodeNodeBalancerNode(),
-			"linode_volume":              resourceLinodeVolume(),
+			"linode_rdns":                resourceLinodeRDNS(),
 			"linode_sshkey":              resourceLinodeSSHKey(),
 			"linode_stackscript":         resourceLinodeStackscript(),
 			"linode_token":               resourceLinodeToken(),
+			"linode_volume":              resourceLinodeVolume(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/linode/resource_linode_rdns.go
+++ b/linode/resource_linode_rdns.go
@@ -3,7 +3,6 @@ package linode
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -29,10 +28,10 @@ func resourceLinodeRDNS() *schema.Resource {
 				ValidateFunc: validation.SingleIP(),
 			},
 			"rdns": {
-				Type:        schema.TypeString,
-				Description: "The reverse DNS assigned to this address. For public IPv4 addresses, this will be set to a default value provided by Linode if not explicitly set.",
-				Optional:    true,
-				Computed:    true,
+				Type:         schema.TypeString,
+				Description:  "The reverse DNS assigned to this address. For public IPv4 addresses, this will be set to a default value provided by Linode if not explicitly set.",
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(3, 254),
 			},
 		},
 	}
@@ -113,7 +112,6 @@ func resourceLinodeRDNSUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error parsing Linode RDNS ID %s as IP string", ipStr)
 	}
 
-	log.Printf("[WARN] MARQUES UPDATING %s with %s", d.Id(), d.Get("rdns"))
 	var rdns *string
 
 	if rdnsRaw, ok := d.GetOk("rdns"); ok && len(rdnsRaw.(string)) > 0 {

--- a/linode/resource_linode_rdns.go
+++ b/linode/resource_linode_rdns.go
@@ -1,0 +1,159 @@
+package linode
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/linode/linodego"
+)
+
+func resourceLinodeRDNS() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLinodeRDNSCreate,
+		Read:   resourceLinodeRDNSRead,
+		Delete: resourceLinodeRDNSDelete,
+		Exists: resourceLinodeRDNSExists,
+		Update: resourceLinodeRDNSUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"address": {
+				Type:         schema.TypeString,
+				Description:  "The public Linode IPv4 or IPv6 address to operate on.",
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.SingleIP(),
+			},
+			"rdns": {
+				Type:        schema.TypeString,
+				Description: "The reverse DNS assigned to this address. For public IPv4 addresses, this will be set to a default value provided by Linode if not explicitly set.",
+				Optional:    true,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceLinodeRDNSExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(linodego.Client)
+
+	ipStr := d.Id()
+
+	if len(ipStr) == 0 {
+		return false, fmt.Errorf("Error parsing Linode RDNS ID as IP string")
+	}
+
+	_, err := client.GetIPAddress(context.Background(), ipStr)
+
+	if err != nil {
+		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
+			d.SetId("")
+			return false, nil
+		}
+
+		return false, fmt.Errorf("Error getting Linode RDNS for %s: %s", ipStr, err)
+	}
+	return true, nil
+}
+
+func resourceLinodeRDNSRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(linodego.Client)
+	ipStr := d.Id()
+
+	if len(ipStr) == 0 {
+		return fmt.Errorf("Error parsing Linode RDNS ID %s as IP string", ipStr)
+	}
+
+	ip, err := client.GetIPAddress(context.Background(), ipStr)
+
+	if err != nil {
+		return fmt.Errorf("Error finding the specified Linode RDNS: %s", err)
+	}
+
+	d.Set("address", d.Id())
+	d.Set("rdns", ip.RDNS)
+
+	return nil
+}
+
+func resourceLinodeRDNSCreate(d *schema.ResourceData, meta interface{}) error {
+	client, ok := meta.(linodego.Client)
+	if !ok {
+		return fmt.Errorf("Invalid Client when creating Linode RDNS")
+	}
+
+	var address = d.Get("address").(string)
+	var rdns *string
+	if rdnsRaw, ok := d.GetOk("rdns"); ok && len(rdnsRaw.(string)) > 0 {
+		rdnsStr := rdnsRaw.(string)
+		rdns = &rdnsStr
+	}
+	updateOpts := linodego.IPAddressUpdateOptions{
+		RDNS: rdns,
+	}
+	ip, err := client.UpdateIPAddress(context.Background(), address, updateOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating a Linode RDNS: %s", err)
+	}
+	d.SetId(address)
+	d.Set("rdns", ip.RDNS)
+
+	return resourceLinodeRDNSRead(d, meta)
+}
+
+func resourceLinodeRDNSUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(linodego.Client)
+	ipStr := d.Id()
+
+	if len(ipStr) == 0 {
+		return fmt.Errorf("Error parsing Linode RDNS ID %s as IP string", ipStr)
+	}
+
+	log.Printf("[WARN] MARQUES UPDATING %s with %s", d.Id(), d.Get("rdns"))
+	var rdns *string
+
+	if rdnsRaw, ok := d.GetOk("rdns"); ok && len(rdnsRaw.(string)) > 0 {
+		rdnsStr := rdnsRaw.(string)
+		rdns = &rdnsStr
+	}
+
+	updateOpts := linodego.IPAddressUpdateOptions{
+		RDNS: rdns,
+	}
+
+	if _, err := client.UpdateIPAddress(context.Background(), d.Id(), updateOpts); err != nil {
+		return fmt.Errorf("Error updating Linode RDNS: %s", err)
+	}
+
+	return resourceLinodeRDNSRead(d, meta)
+}
+
+func resourceLinodeRDNSDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(linodego.Client)
+	ipStr := d.Id()
+
+	if len(ipStr) == 0 {
+		return fmt.Errorf("Error parsing Linode RDNS ID %s as IP string", ipStr)
+	}
+
+	updateOpts := linodego.IPAddressUpdateOptions{
+		RDNS: nil,
+	}
+
+	if _, err := client.UpdateIPAddress(context.Background(), d.Id(), updateOpts); err != nil {
+		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error deleting Linode RDNS: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/linode/resource_linode_rdns_test.go
+++ b/linode/resource_linode_rdns_test.go
@@ -1,0 +1,182 @@
+package linode
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/linode/linodego"
+)
+
+func init() {
+	resource.AddTestSweepers("linode_rdns", &resource.Sweeper{
+		Name: "linode_rdns",
+		F:    testSweepLinodeRDNS,
+	})
+}
+
+func testSweepLinodeRDNS(prefix string) error {
+	client, err := getClientForSweepers()
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+
+	ips, err := client.ListIPAddresses(context.Background(), nil)
+	if err != nil {
+		return fmt.Errorf("Error getting IPAddresses: %s", err)
+	}
+	updateOpts := linodego.IPAddressUpdateOptions{RDNS: nil}
+	for _, ip := range ips {
+		if !shouldSweepAcceptanceTestResource(prefix, ip.RDNS) {
+			continue
+		}
+		_, err := client.UpdateIPAddress(context.Background(), ip.Address, updateOpts)
+
+		if err != nil {
+			return fmt.Errorf("Error clearing RDNS %s during sweep: %s", ip.RDNS, err)
+		}
+	}
+
+	return nil
+}
+
+func TestAccLinodeRDNS_basic(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_rdns.foobar"
+	var linodeLabel = acctest.RandomWithPrefix("tf_test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLinodeRDNSDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckLinodeRDNSBasic(linodeLabel),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeRDNSExists,
+					resource.TestMatchResourceAttr(resName, "rdns", regexp.MustCompile(`.nip.io$`)),
+				),
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLinodeRDNS_update(t *testing.T) {
+	t.Parallel()
+
+	var label = acctest.RandomWithPrefix("tf_test")
+	resName := "linode_rdns.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLinodeRDNSDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckLinodeRDNSBasic(label),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeRDNSExists,
+					resource.TestCheckResourceAttrPair(resName, "address", "linode_instance.foobar", "ip_address"),
+					resource.TestMatchResourceAttr(resName, "rdns", regexp.MustCompile(`.nip.io$`)),
+				),
+			},
+			{
+				Config: testAccCheckLinodeRDNSReset(label),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeRDNSExists,
+					resource.TestMatchResourceAttr(resName, "rdns", regexp.MustCompile(`.members.linode.com$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckLinodeRDNSExists(s *terraform.State) error {
+	client := testAccProvider.Meta().(linodego.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "linode_rdns" {
+			continue
+		}
+
+		_, err := client.GetIPAddress(context.Background(), rs.Primary.Attributes["address"])
+
+		if err != nil {
+			return fmt.Errorf("Error retrieving state of RDNS %s: %s", rs.Primary.Attributes["rdns"], err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckLinodeRDNSDestroy(s *terraform.State) error {
+	client, ok := testAccProvider.Meta().(linodego.Client)
+	if !ok {
+		return fmt.Errorf("Error getting Linode client")
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "linode_rdns" {
+			continue
+		}
+
+		id := rs.Primary.ID
+		ip, err := client.GetIPAddress(context.Background(), id)
+
+		if err != nil {
+			if apiErr, ok := err.(*linodego.Error); ok && apiErr.Code == 404 {
+				return nil
+			}
+
+			if ip.RDNS[len(ip.RDNS)-len("members.linode.com"):] == "members.linode.com" {
+				return nil
+			}
+
+			return fmt.Errorf("Linode RDNS with IP %s still exists: %s", id, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckLinodeRDNSBasic(label string) string {
+	return fmt.Sprintf(`
+resource "linode_instance" "foobar" {
+	label = "%s"
+	group = "tf_test"
+	image = "linode/containerlinux"
+	type = "g6-standard-1"
+	region = "us-east"
+}
+
+resource "linode_rdns" "foobar" {
+	address = "${linode_instance.foobar.ip_address}"
+	rdns = "${linode_instance.foobar.ip_address}.nip.io"
+}`, label)
+}
+
+func testAccCheckLinodeRDNSReset(label string) string {
+	return fmt.Sprintf(`
+resource "linode_instance" "foobar" {
+	label = "%s"
+	group = "tf_test"
+	image = "linode/containerlinux"
+	type = "g6-standard-1"
+	region = "us-east"
+}
+
+resource "linode_rdns" "foobar" {
+	rdns    = ""
+	address = "${linode_instance.foobar.ip_address}"
+}
+`, label)
+}

--- a/website/docs/d/network_ip.html.md
+++ b/website/docs/d/network_ip.html.md
@@ -1,0 +1,49 @@
+---
+layout: "linode"
+page_title: "Linode: linode_network_ip"
+sidebar_current: "docs-linode-datasource-network-ip"
+description: |-
+  Provides details about a Linode Network IP Address.
+---
+
+# Data Source: linode\_network\_ip
+
+Provides information about a Linode Network IP Address
+
+## Example Usage
+
+The following example shows how one might use this data source to access information about a Linode Network IP Address.
+
+```hcl
+data "linode_image" "ns1_linode_com" {
+    address = "162.159.27.72"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `address` - (Required) The IP Address to access.  The address must be associated with the account and a resource that the user has access to view.
+
+## Attributes
+
+The Linode Network IP Address resource exports the following attributes:
+
+* `address` - The IP address.
+
+* `gateway` - The default gateway for this address.
+
+* `subnet_mask` - The mask that separates host bits from network bits for this address.
+
+* `prefix` - The number of bits set in the subnet mask.
+
+* `type` - The type of address this is (ipv4, ipv6, ipv6/pool, ipv6/range).
+
+* `public` - Whether this is a public or private IP address.
+
+* `rdns` - The reverse DNS assigned to this address. For public IPv4 addresses, this will be set to a default value provided by Linode if not explicitly set.
+
+* `linode_id` - The ID of the Linode this address currently belongs to.
+
+* `region` - The Region this IP address resides in.

--- a/website/docs/d/networking_ip.html.md
+++ b/website/docs/d/networking_ip.html.md
@@ -1,18 +1,18 @@
 ---
 layout: "linode"
-page_title: "Linode: linode_network_ip"
-sidebar_current: "docs-linode-datasource-network-ip"
+page_title: "Linode: linode_networking_ip"
+sidebar_current: "docs-linode-datasource-networking-ip"
 description: |-
-  Provides details about a Linode Network IP Address.
+  Provides details about a Linode Networking IP Address.
 ---
 
 # Data Source: linode\_network\_ip
 
-Provides information about a Linode Network IP Address
+Provides information about a Linode Networking IP Address
 
 ## Example Usage
 
-The following example shows how one might use this data source to access information about a Linode Network IP Address.
+The following example shows how one might use this data source to access information about a Linode Networking IP Address.
 
 ```hcl
 data "linode_image" "ns1_linode_com" {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -34,6 +34,14 @@ The following keys can be used to configure the provider.
 
    The Linode Token can also be specified using the `LINODE_TOKEN` environment variable.
 
+* `url` - (Optional) The HTTP(S) API address of the Linode API to use.
+
+   The Linode API URL can also be specified using the `LINODE_URL` environment variable.
+
+* `ua_prefix` - (Optional) An HTTP User-Agent Prefix to prepend in API requests.
+
+   The User-Agent Prefix can also be specified using the `LINODE_UA_PREFIX` environment variable.
+
 ## Linode Guides
 
 Several [Linode Guides & Tutorials](https://www.linode.com/docs/) are available that explore Terraform usage with Linode resources:

--- a/website/docs/r/instance.html.md
+++ b/website/docs/r/instance.html.md
@@ -222,9 +222,9 @@ This Linode Instance resource exports the following attributes:
 
 * `ip_address` - A string containing the Linode's public IP address.
 
-* `private_ip_address` - This Linode's Private IPv4 Address, if enabled.  The regional private IP address range is 192.168.128/17 address shared by all Linode Instances in a region.
+* `private_ip_address` - This Linode's Private IPv4 Address, if enabled.  The regional private IP address range, 192.168.128.0/17, is shared by all Linode Instances in a region.
 
-* `ipv6` - This Linode's IPv6 SLAAC addresses. This address is specific to a Linode, and may not be shared.
+* `ipv6` - This Linode's IPv6 SLAAC addresses. This address is specific to a Linode, and may not be shared.  The prefix (`/64`) is included in this attribute.
 
 * `ipv4` - This Linode's IPv4 Addresses. Each Linode is assigned a single public IPv4 address upon creation, and may get a single private IPv4 address if needed. You may need to open a support ticket to get additional IPv4 addresses.
 

--- a/website/docs/r/rdns.html.md
+++ b/website/docs/r/rdns.html.md
@@ -1,0 +1,48 @@
+---
+layout: "linode"
+page_title: "Linode: linode_rdns"
+sidebar_current: "docs-linode-resource-rdns"
+description: |-
+  Manages the RDNS / PTR record for the IP Address associated with a Linode Instance.
+---
+
+# linode\_rdns
+
+Provides a Linode RDNS resource.  This can be used to create, modify, and reset RDNS records.
+
+Linode RDNS names must have a matching address value in an A or AAAA record.  This A or AAAA name must be resolvable at the time the RDNS resource is being associated.
+
+For more information, see the [Linode APIv4 docs](https://developers.linode.com/api/docs/v4#operation/updateIP) and the [Configure your Linode for Reverse DNS](https://www.linode.com/docs/networking/dns/configure-your-linode-for-reverse-dns-classic-manager/) guide.
+
+## Example Usage
+
+The following example shows how one might use this resource to configure an RDNS address for an IP address.
+
+```hcl
+resource "linode_rdns" "foo" {
+  address = "${linode_instance.foo.ip_address}"
+  rdns = "${linode_instance.foo.ip_address}.nip.io"
+}
+
+resource "linode_instance" "foo" {
+   image = "linode/alpine3.9"
+   region = "ca-east"
+   type = "g6-dedicated-2"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `address` - The Public IPv4 or IPv6 address that will receive the `PTR` record.  A matching `A` or `AAAA` record must exist.
+
+* `rdns` - The name of the RDNS 
+
+## Import
+
+Linodes RDNS resources can be imported using the address as the `id`.
+
+```sh
+terraform import linode_rdns.foo 123.123.123.123
+```

--- a/website/docs/r/rdns.html.md
+++ b/website/docs/r/rdns.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # linode\_rdns
 
-Provides a Linode RDNS resource.  This can be used to create, modify, and reset RDNS records.
+Provides a Linode RDNS resource.  This can be used to create and modify RDNS records.
 
 Linode RDNS names must have a matching address value in an A or AAAA record.  This A or AAAA name must be resolvable at the time the RDNS resource is being associated.
 
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `address` - The Public IPv4 or IPv6 address that will receive the `PTR` record.  A matching `A` or `AAAA` record must exist.
 
-* `rdns` - The name of the RDNS 
+* `rdns` - The name of the RDNS address.
 
 ## Import
 

--- a/website/linode.erb
+++ b/website/linode.erb
@@ -64,6 +64,9 @@
             <li<%= sidebar_current("docs-linode-resource-nodebalancer_node") %>>
               <a href="/docs/providers/linode/r/nodebalancer_node.html">linode_nodebalancer_node</a>
             </li>
+            <li<%= sidebar_current("docs-linode-resource-rdns") %>>
+              <a href="/docs/providers/linode/r/rdns.html">linode_rdns</a>
+            </li>
             <li<%= sidebar_current("docs-linode-resource-sshkey") %>>
               <a href="/docs/providers/linode/r/sshkey.html">linode_sshkey</a>
             </li>

--- a/website/linode.erb
+++ b/website/linode.erb
@@ -25,6 +25,9 @@
             <li<%= sidebar_current("docs-linode-datasource-instance-type") %>>
               <a href="/docs/providers/linode/d/instance_type.html">linode_instance_type</a>
             </li>
+            <li<%= sidebar_current("docs-linode-datasource-networking-ip") %>>
+              <a href="/docs/providers/linode/d/networking_ip.html">linode_networking_ip</a>
+            </li>
             <li<%= sidebar_current("docs-linode-datasource-profile") %>>
               <a href="/docs/providers/linode/d/profile.html">linode_profile</a>
             </li>


### PR DESCRIPTION
Adds the `linode_rdns` resource which takes a single "address" and "rdns" value.
* "address" can refer to a public IPv4 or IPv6 address assigned to a Linode on the account
   "address" can also included any IPv6 addresses in a`/56` or `/64` range assigned to a Linode, or a floating `/116` pool which can be used by any Linode within a region without a specific reservation
* "rdns" must refer to an "A" or "AAAA" DNS name that refers to the address

Testing takes advantage of nip.io which can be used to return an "A" record for any IP address.  Linode requires that any RDNS ("PTR") records created already have a matching "A" record.

The API endpoints that this resource maps to are:

* [`GET /networking/ips/{address}`](https://developers.linode.com/api/docs/v4#operation/getIP) (address details, including RDNS)
* [`PUT /networking/ips/{address}`](https://developers.linode.com/api/docs/v4#operation/updateIP) (set RDNS)

Since the only `{address}` values that can be provided are ones that map to a Linode on the account, and every IPv4 address comes with a default RDNS (`li123-456.members.linode.com`), "deleting" an RDNS entry effectively means reseting the RDNS, by sending a `{ rnds: null }` value in a `PUT` request.

This resource does not fit the traditional CRUD model:

• **C**REATE: *You can't create an address.* It must preexist on the account (via instance creation or support).  You can create an RDNS association with an address, which the resource enables.
• **R**EAD: This will always work if the address maps to something available on the account which the user has rights to access.  This resource lets you read the address RDNS value.
• **U**PDATE: This will work to set RDNS for any addresses on the account.  This resource allows the changing of the RDNS name associated with an address.
• **D**ELETE:  *You can't delete an address.*  You can clear the "RDNS" name by `PUT`'ing a `null` value, which resets the RDNS name back to "something.members.linode.com", or perhaps "" for ipv6 addresses.  This resource handles deletes by resetting the RDNS name.

This resource was designed as an independent resource rather than a field or map of the `linode_instance` resource.  Linodes can have multiple IPv4 addresses.  Linodes can also use any IPv6 address in a floating `/116` pool throughout a region, not tied to a specific Linode.  RDNS names can be assigned to any of these additional addresses.

Closes https://github.com/terraform-providers/terraform-provider-linode/issues/12


---
```hcl
resource "linode_rdns" "foo" {
  address = "${linode_instance.foo.ip_address}"
  // The Linode API enforces that potential RDNS names must be already have
  // an A or AAAA record pointed to the address.  "nip.io" is a service that provides this.
  rdns = "${linode_instance.foo.ip_address}.nip.io"

  // Clear the rdns to the default ("something.members.linode.com")
  // Deleting the resource will also result in the RDNS name being reset.
  // rdns = ""
}

resource "linode_instance" "foo" {
   image = "linode/alpine3.9"
   region = "ca-east"
   type = "g6-dedicated-2"
}
```