### PR TITLE
Accept "0" in Domain and Domain Record time-in-seconds related fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ ENHANCEMENTS:
 BUG FIXES:
 
 * Documentation and examples for `linode_domain` resource were missing required `type` field
+* `linode_domain_record` field `ttl_sec` accepts `0`, as the API does (#35)
+* `linode_domain` fields `ttl_sec`, `retry_sec`, `expire_sec`, and `refresh_sec` now accept `0`, as the API does
 
 ## 1.5.0 (February 06, 2019)
 

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -29,7 +29,7 @@ func Provider() terraform.ResourceProvider {
 			"url": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("LINODE_URL", ""),
+				DefaultFunc: schema.EnvDefaultFunc("LINODE_URL", nil),
 				Description: "The HTTP(S) API address of the Linode API to use.",
 			},
 			"ua_prefix": {
@@ -82,12 +82,12 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, fmt.Errorf("The Linode API URL was not valid")
 	}
 
-	ua_prefix, ok := d.Get("ua_prefix").(string)
+	uaPrefix, ok := d.Get("ua_prefix").(string)
 	if !ok {
 		return nil, fmt.Errorf("The Linode UA Prefix was not valid")
 	}
 
-	client := getLinodeClient(token, url, ua_prefix)
+	client := getLinodeClient(token, url, uaPrefix)
 	// Ping the API for an empty response to verify the configuration works
 	_, err := client.ListTypes(context.Background(), linodego.NewListOptions(100, ""))
 	if err != nil {
@@ -97,7 +97,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	return client, nil
 }
 
-func getLinodeClient(token, url, ua_prefix string) linodego.Client {
+func getLinodeClient(token, url, uaPrefix string) linodego.Client {
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 
 	oauthTransport := &oauth2.Transport{
@@ -114,8 +114,8 @@ func getLinodeClient(token, url, ua_prefix string) linodego.Client {
 	userAgent := fmt.Sprintf("Terraform/%s (+%s) linodego/%s",
 		version.String(), projectURL, linodego.Version)
 
-	if len(ua_prefix) > 0 {
-		userAgent = ua_prefix + " " + userAgent
+	if len(uaPrefix) > 0 {
+		userAgent = uaPrefix + " " + userAgent
 	}
 
 	var baseURL = DefaultLinodeURL

--- a/linode/resource_linode_domain.go
+++ b/linode/resource_linode_domain.go
@@ -74,25 +74,25 @@ func resourceLinodeDomain() *schema.Resource {
 			},
 			"ttl_sec": {
 				Type:         schema.TypeInt,
-				Description:  "'Time to Live' - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
+				Description:  "'Time to Live' - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers. Valid values are 0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
 				ValidateFunc: validDomainSeconds,
 				Optional:     true,
 			},
 			"retry_sec": {
 				Type:         schema.TypeInt,
-				Description:  "The interval, in seconds, at which a failed refresh should be retried. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
+				Description:  "The interval, in seconds, at which a failed refresh should be retried. Valid values are 0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
 				ValidateFunc: validDomainSeconds,
 				Optional:     true,
 			},
 			"expire_sec": {
 				Type:         schema.TypeInt,
-				Description:  "The amount of time in seconds that may pass before this Domain is no longer authoritative. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
+				Description:  "The amount of time in seconds that may pass before this Domain is no longer authoritative. Valid values are 0, 00, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
 				ValidateFunc: validDomainSeconds,
 				Optional:     true,
 			},
 			"refresh_sec": {
 				Type:         schema.TypeInt,
-				Description:  "The amount of time in seconds before this Domain should be refreshed. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
+				Description:  "The amount of time in seconds before this Domain should be refreshed. Valid values are 0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
 				ValidateFunc: validDomainSeconds,
 				Optional:     true,
 			},
@@ -133,7 +133,7 @@ func intInSlice(valid []int) schema.SchemaValidateFunc {
 }
 
 func domainSecondsValidator() schema.SchemaValidateFunc {
-	validSeconds := []int{300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, 2419200}
+	validSeconds := []int{0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, 2419200}
 	return intInSlice(validSeconds)
 }
 

--- a/linode/resource_linode_domain_record.go
+++ b/linode/resource_linode_domain_record.go
@@ -46,7 +46,7 @@ func resourceLinodeDomainRecord() *schema.Resource {
 			},
 			"ttl_sec": {
 				Type:         schema.TypeInt,
-				Description:  "'Time to Live' - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
+				Description:  "'Time to Live' - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers. Valid values are 0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
 				ValidateFunc: validDomainSeconds,
 				Optional:     true,
 			},


### PR DESCRIPTION
Accept 0 in domain and domain_record ttl_sec, retry_sec, expire_sec, refresh_sec fields

The API permits and returns `0` for these fields even though the documented behavior suggests that this will be treated as `300`s.

Closes https://github.com/terraform-providers/terraform-provider-linode/issues/35