### PR TITLE
fix root_device handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.8.0 (Unreleased)
+
+BACKWARDS INCOMPATIBILITIES / NOTES:
+
+* resource/linode\_instance: `config.root_device` no longer supplies `/dev/root` when no `/dev/sda` device is present (this was an API work-around that is no longer needed) ([#10](https://github.com/terraform-providers/terraform-provider-linode/issues/10), [#18](https://github.com/terraform-providers/terraform-provider-linode/issues/18))
+
 ## 1.7.0 (July 08, 2019)
 
 ENHANCEMENTS:
@@ -12,7 +17,6 @@ BUG FIXES:
 * The Linode API resizes disks by default when an instance is resized. This behavior is now accounted for -- Terraform will not resize disks unless a new size is specified in the config.
 * The provider now waits for instance resizing to complete before attempting to issue disk resize jobs against an instance. This was required because new jobs issued to actively-resizing instances fail.
 * Disk resizing and instance resizing are now executed in the correct order.
-
 
 ## 1.6.0 (April 10, 2019)
 

--- a/linode/resource_linode_instance_test.go
+++ b/linode/resource_linode_instance_test.go
@@ -529,7 +529,7 @@ func TestAccLinodeInstance_configUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
 					resource.TestCheckResourceAttr(resName, "group", "tf_test"),
 					resource.TestCheckResourceAttr(resName, "config.0.kernel", "linode/latest-64bit"),
-					resource.TestCheckResourceAttr(resName, "config.0.root_device", "/dev/root"),
+					resource.TestCheckResourceAttr(resName, "config.0.root_device", "/dev/sda"),
 					resource.TestCheckResourceAttr(resName, "config.0.helpers.0.network", "true"),
 					resource.TestCheckResourceAttr(resName, "alerts.0.cpu", "60"),
 				),
@@ -543,7 +543,7 @@ func TestAccLinodeInstance_configUpdate(t *testing.T) {
 					// changed kerel, not label
 					resource.TestCheckResourceAttr(resName, "config.0.label", "config"),
 					resource.TestCheckResourceAttr(resName, "config.0.kernel", "linode/latest-32bit"),
-					resource.TestCheckResourceAttr(resName, "config.0.root_device", "/dev/root"),
+					resource.TestCheckResourceAttr(resName, "config.0.root_device", "/dev/sda"),
 					resource.TestCheckResourceAttr(resName, "config.0.helpers.0.network", "false"),
 					resource.TestCheckResourceAttr(resName, "alerts.0.cpu", "80"),
 				),
@@ -1381,7 +1381,7 @@ resource "linode_instance" "foobar" {
 	config {
 		label = "config"
 		kernel = "linode/latest-64bit"
-		root_device = "/dev/root"
+		root_device = "/dev/sda"
 		helpers {
 			network = true
 		}
@@ -1401,12 +1401,12 @@ resource "linode_instance" "foobar" {
 	config {
 		label = "configa"
 		kernel = "linode/latest-64bit"
-		root_device = "/dev/root"
+		root_device = "/dev/sda"
 	}
 	config {
 		label = "configb"
 		kernel = "linode/latest-32bit"
-		root_device = "/dev/root"
+		root_device = "/dev/sda"
 	}
 
 	boot_config_label = "configa"
@@ -1423,12 +1423,12 @@ resource "linode_instance" "foobar" {
 	config {
 		label = "configa"
 		kernel = "linode/latest-64bit"
-		root_device = "/dev/root"
+		root_device = "/dev/sda"
 	}
 	config {
 		label = "configb"
 		kernel = "linode/latest-32bit"
-		root_device = "/dev/root"
+		root_device = "/dev/sda"
 	}
 
 	boot_config_label = "configa"
@@ -1446,19 +1446,19 @@ resource "linode_instance" "foobar" {
 		label = "configa"
 		comments = "configa"
 		kernel = "linode/latest-32bit"
-		root_device = "/dev/root"
+		root_device = "/dev/sda"
 	}
 	config {
 		label = "configb"
 		comments = "configb"
 		kernel = "linode/latest-64bit"
-		root_device = "/dev/root"
+		root_device = "/dev/sda"
 	}
 	config {
 		label = "configc"
 		comments = "configc"
 		kernel = "linode/latest-64bit"
-		root_device = "/dev/root"
+		root_device = "/dev/sda"
 	}
 
 	boot_config_label = "configa"
@@ -1795,7 +1795,7 @@ resource "linode_instance" "foobar" {
 	config {
 		label = "config"
 		kernel = "linode/latest-64bit"
-		root_device = "/dev/root"
+		root_device = "/dev/sda"
 	}
 
 	boot_config_label = "config"
@@ -1818,7 +1818,7 @@ resource "linode_instance" "foobar" {
 	config {
 		label = "config"
 		kernel = "linode/latest-32bit"
-		root_device = "/dev/root"
+		root_device = "/dev/sda"
 		helpers {
 			network = false
 		}


### PR DESCRIPTION
This PR is in response to API changes: https://developers.linode.com/changelog/api/ 4.0.23 and allows for the `/dev/root` work-around to be removed.

> Changed validation criteria when updating (PUT /linode/instances/{linodeId}/configs/{configId}) the devices property for a Linode’s configuration profile.
> * An empty devices object or a devices object with empty values for device slots is allowed on PUT only if an empty device map already exits. An error will result if a non-empty device map exists for the Linode’s configuration profile.
> * If no devices are specified, booting from this configuration will hold waiting for a device to exist before being able to boot.
> * Previous validation produced an error in all cases when an empty device object or a devices object with empty values for device slots was passed on PUT.
>
> Changed validation criteria and behavior when creating (POST /linode/instances/{linodeId}/configs) and updating (PUT /linode/instances/{linodeId}/configs/{configId})the root_device property for a Linode’s configuration profile.
> * If no value or an invalid value is provided, root_device will default to /dev/sda.
> * Previous validation for PUT errored when no value was provided for root_device and an empty device map existed for the Linode’s configuration profile.
> * If the device specified at the root device location is not mounted, the Linode will not boot until a device is mounted.

Closes #10 
Closes #18

