### PR TITLE
provider: Clean up UA header handling

### DIFF
--- a/linode/provider.go
+++ b/linode/provider.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/httpclient"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/hashicorp/terraform/version"
 	"github.com/linode/linodego"
 	"golang.org/x/oauth2"
 )
@@ -110,9 +110,10 @@ func getLinodeClient(token, url, uaPrefix string) linodego.Client {
 
 	client := linodego.NewClient(oauth2Client)
 
-	projectURL := "https://www.terraform.io"
-	userAgent := fmt.Sprintf("Terraform/%s (+%s) linodego/%s",
-		version.String(), projectURL, linodego.Version)
+	terraformVersion := httpclient.UserAgentString()
+	projectURL := "(+https://www.terraform.io)"
+	sdkVersion := fmt.Sprintf("linodego/%s", linodego.Version)
+	userAgent := fmt.Sprintf("%s %s %s", terraformVersion, projectURL, sdkVersion)
 
 	if len(uaPrefix) > 0 {
 		userAgent = uaPrefix + " " + userAgent


### PR DESCRIPTION
This aligns handling of User-Agent with most other providers, e.g. Google:

https://github.com/terraform-providers/terraform-provider-google/blob/562e234e46e6cf92c9f546759f3b5bf960f5154f/google/config.go#L126-L129

Azure

https://github.com/terraform-providers/terraform-provider-azurerm/blob/361fb2d7919604da055c6c34160c4c1fcf6fe8aa/azurerm/config.go#L322-L326

or Fastly

https://github.com/terraform-providers/terraform-provider-fastly/blob/cf2201e03b9444cdd3ab477688276379c250970c/fastly/config.go#L30

The main motivation behind this is to remove dependency of this provider on the `version` package, and reduce the surface of Terraform core exposed to this provider. We're in initial planning phases of decoupling SDK logic (basically all of `helper/*` packages) from Terraform into its own project.
One of (many) motivations behind doing this is also to simplify dependency tree of a provider.

The future SDK will have to figure out a way of getting Terraform version somehow, but providers shouldn't need to know how and shouldn't need to import `hashicorp/terraform`.

Just to clarify: This SDK doesn't exist yet, there will be separate communication efforts as we begin to work on it.