### PR TITLE
resize disks only against powered-off instances.

### DIFF
--- a/linode/linode_instance_helpers.go
+++ b/linode/linode_instance_helpers.go
@@ -724,7 +724,9 @@ func changeInstanceDiskSize(client *linodego.Client, instance linodego.Instance,
 		if _, err := client.WaitForInstanceStatus(context.Background(), instance.ID, linodego.InstanceOffline, int(d.Timeout(schema.TimeoutUpdate).Seconds())); err != nil {
 			return fmt.Errorf("Error waiting for instance %d to go offline: %s", instance.ID, err)
 		} else {
-			client.ResizeInstanceDisk(context.Background(), instance.ID, disk.ID, targetSize)
+			if err := client.ResizeInstanceDisk(context.Background(), instance.ID, disk.ID, targetSize); err != nil {
+				return fmt.Errorf("Error resizing Disk %d for Instance %d: %s", disk.ID, instance.ID, err)
+			}
 		}
 
 		// Wait for the Disk Resize Operation to Complete, and boot instance.

--- a/linode/resource_linode_instance_test.go
+++ b/linode/resource_linode_instance_test.go
@@ -933,8 +933,6 @@ func TestAccLinodeInstance_diskResizeAndExpanded(t *testing.T) {
 	})
 }
 
-
-
 func TestAccLinodeInstance_diskSlotReorder(t *testing.T) {
 	t.Parallel()
 	var (
@@ -1655,7 +1653,6 @@ resource "linode_instance" "foobar" {
 	}
 }`, instance, pubkey)
 }
-
 
 func testAccCheckLinodeInstanceWithDiskAndConfigAddedAndReordered(instance string, pubkey string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
Since disks can only be resized on powered-off Linodes, we need to issue a shutdown job prior to resizing. This issues a shutdown job, waits for the InstanceStatus to be "Offline," then resizes the disk and boots the instance.