### PR TITLE
Add persist_across_boots argument for the linode_volume resource

### DIFF
--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 * `tags` - (Optional) A list of tags applied to this object. Tags are for organizational purposes only.
 
-* `persist_across_boots` - (Optional) If false, volumes will not be reattached by Linode on reboot.
+* `persist_across_boots` - (Optional) If false, volumes will not be reattached by Linode on reboot. Defaults to true.
 
 ### Timeouts
 

--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -67,6 +67,8 @@ The following arguments are supported:
 
 * `tags` - (Optional) A list of tags applied to this object. Tags are for organizational purposes only.
 
+* `persist_across_boots` - (Optional) If false, volumes will not be reattached by Linode on reboot.
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
I was taking a look at the `VolumeCreateOptions` struct in the Linode Go Client and noticed there was the `PersistAcrossBoots` option so I took a crack at adding the `persist_across_boots` argument for the `linode_volume` resource. Hopefully it is helpful!