### PR TITLE
Unhandled err variable

### DIFF
--- a/linode/resource_linode_image.go
+++ b/linode/resource_linode_image.go
@@ -112,6 +112,9 @@ func resourceLinodeImageRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(linodego.Client)
 
 	image, err := client.GetImage(context.Background(), d.Id())
+	if err != nil {
+		return fmt.Errorf("Error retrieving the specified Linode Image: %s", err)
+	}
 
 	found, err := resourceLinodeImageExists(d, meta)
 	if err != nil {


### PR DESCRIPTION
Noticed an unhandled `err` variable in `resourceLinodeImageRead` so added a small check for it.