### PR TITLE
make obj secret key accessible

### DIFF
--- a/linode/resource_linode_object_storage_key.go
+++ b/linode/resource_linode_object_storage_key.go
@@ -15,9 +15,6 @@ func resourceLinodeObjectStorageKey() *schema.Resource {
 		Read:   resourceLinodeObjectStorageKeyRead,
 		Update: resourceLinodeObjectStorageKeyUpdate,
 		Delete: resourceLinodeObjectStorageKeyDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
 
 		Schema: map[string]*schema.Schema{
 			"label": {
@@ -57,6 +54,9 @@ func resourceLinodeObjectStorageKeyCreate(d *schema.ResourceData, meta interface
 	d.Set("label", objectStorageKey.Label)
 	d.Set("access_key", objectStorageKey.AccessKey)
 
+	// secret_key only available on creation
+	d.Set("secret_key", objectStorageKey.SecretKey)
+
 	return resourceLinodeObjectStorageKeyRead(d, meta)
 }
 
@@ -75,8 +75,6 @@ func resourceLinodeObjectStorageKeyRead(d *schema.ResourceData, meta interface{}
 
 	d.Set("label", objectStorageKey.Label)
 	d.Set("access_key", objectStorageKey.AccessKey)
-	d.Set("secret_key", objectStorageKey.SecretKey)
-
 	return nil
 }
 


### PR DESCRIPTION
Closes #78

This will allow a given `linode_object_sotrage_key.secret_key` to be stored in tfstate on initial creation. The `secret_key` will never be refetched in subsequent read ops. So as long as the initial tfstate is preserved, the key is accessible.

Because at an API level we restrict refetching the `secret_key`, the importer for this resource has been removed. It's worthless to import as it cannot be used to provision access to buckets for customers.