### PR TITLE
remove deprecated travis sudo key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: trusty
-sudo: required
 services:
 - docker
 language: go


### PR DESCRIPTION
Travis-CI is now recommending the removal of the `sudo` config key:

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration