### PR TITLE
include terraform + provider version in useragent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.10.0 (Unreleased)
 
+ENHANCEMENTS:
+
+* Provide more version/client information in the User-Agent header. By default now, the header will include the Terraform CLI, terraform-provider-linode, and linodego versions.
+
 BUG FIXES:
 
 * `swap_size` attribute changes would not change the underlying swap disk's size as the boot disk size was fixed from creation. This will now actually change the swap disk size and scale the boot disk as needed.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -54,7 +54,7 @@ test: fmtcheck
 testacc: fmtcheck
 	TF_ACC=1 \
 	LINODE_API_VERSION="v4beta" \
-	go test $(TEST) -v $(TESTARGS) -timeout 120m -parallel=2
+	go test $(TEST) -v $(TESTARGS) -timeout 120m -parallel=2 -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
 
 vet:
 	@echo "go vet ."

--- a/linode/config.go
+++ b/linode/config.go
@@ -1,0 +1,58 @@
+package linode
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
+	"github.com/hashicorp/terraform-plugin-sdk/httpclient"
+	"github.com/linode/linodego"
+	"github.com/terraform-providers/terraform-provider-linode/version"
+	"golang.org/x/oauth2"
+)
+
+// DefaultLinodeURL is the Linode APIv4 URL to use
+const DefaultLinodeURL = "https://api.linode.com/v4"
+
+// Config represents the Linode provider configuration
+type Config struct {
+	AccessToken string
+	APIURL      string
+	APIVersion  string
+	UAPrefix    string
+
+	terraformVersion string
+}
+
+// Client returns a fully initialized Linode client
+func (c *Config) Client() linodego.Client {
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: c.AccessToken})
+	oauthTransport := &oauth2.Transport{
+		Source: tokenSource,
+	}
+	loggingTransport := logging.NewTransport("Linode", oauthTransport)
+
+	oauth2Client := &http.Client{
+		Transport: loggingTransport,
+	}
+	client := linodego.NewClient(oauth2Client)
+
+	tfUserAgent := httpclient.TerraformUserAgent(c.terraformVersion)
+	userAgent := strings.TrimSpace(fmt.Sprintf("%s terraform-provider-linode/%s linodego/%s",
+		tfUserAgent, version.ProviderVersion, linodego.Version))
+	if c.UAPrefix != "" {
+		userAgent = c.UAPrefix + " " + userAgent
+	}
+	client.SetUserAgent(userAgent)
+
+	if c.APIURL != "" {
+		client.SetBaseURL(c.APIURL)
+	} else if len(c.APIVersion) > 0 {
+		client.SetAPIVersion(c.APIVersion)
+	} else {
+		client.SetBaseURL(DefaultLinodeURL)
+	}
+
+	return client
+}

--- a/linode/linode_sweeper_test.go
+++ b/linode/linode_sweeper_test.go
@@ -17,11 +17,12 @@ func TestMain(m *testing.M) {
 
 func getClientForSweepers() (*linodego.Client, error) {
 	token := os.Getenv("LINODE_TOKEN")
-
 	if token == "" {
 		return nil, fmt.Errorf("LINODE_TOKEN must be set for acceptance tests")
 	}
-	client := getLinodeClient(token, "", "", "v4beta")
+
+	config := &Config{AccessToken: token, APIVersion: "v4beta"}
+	client := config.Client()
 	return &client, nil
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+var (
+	// ProviderVersion is set at build-time in the release process
+	ProviderVersion = "dev"
+)


### PR DESCRIPTION
Changes to include terraform, provider, and linodego version information to useragent.

In order to get the provider version at runtime, we expose a variable, `version.ProviderVersion`, which will be set at build-time during the internal Terraform release process. Many providers have adopted this pattern; see [here](https://github.com/search?q=version.ProviderVersion+org%3Aterraform-providers&type=Code) and [here](https://hashicorp.slack.com/archives/C0HSE5WMB/p1570491636145200).

There was also a minor refactor to adopt a provider-config model that can be built on more later.

The resulting UserAgent header looks like this when building from master:
```
User-Agent: HashiCorp Terraform/0.12.23 (+https://www.terraform.io) Terraform Plugin SDK/1.7.0 terraform-provider-linode/dev linodego/0.12.0
```
And will look this next release (v1.9.3)
```
User-Agent: HashiCorp Terraform/0.12.23 (+https://www.terraform.io) Terraform Plugin SDK/1.7.0 terraform-provider-linode/1.9.3 linodego/0.12.0
```