### PR TITLE
Allow A record creation without a name

### DIFF
--- a/linode/resource_linode_domain_record.go
+++ b/linode/resource_linode_domain_record.go
@@ -218,7 +218,7 @@ func validateDomainRecord(c *linodego.Client, rec *linodego.DomainRecord, domain
 	if rec.Type == linodego.RecordTypeSRV {
 		return validateSRVDomainRecord(c, rec, domainID)
 	}
-	if rec.Name == "" {
+	if rec.Name == "" && rec.Type != linodego.RecordTypeA {
 		return errors.New(errLinodeDomainRecordNameRequired)
 	}
 	return nil


### PR DESCRIPTION
I recently noticed that as of https://github.com/terraform-providers/terraform-provider-linode/pull/88 it is no longer possible to create an A record via this terraform provider without the name field being set.

This broke a workflow for me and I see that the constraint is not within the Linode API itself, but rather the terraform validation logic.

Given that the Linode API does not have this constraint (works fine via the portal and via this branch), could we update this logic so that it matches the API?

I've only made this change to illustrate the issue, aware that there is more work to be done and I'm happy to do that.