### PR TITLE
update linodego and don't rely on volume timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 1.12.0 (Unreleased)
+## 1.11.1 (Unreleased)
+
+BUG FIXES:
+
+* Fixed an issue where a missing `Update` timestamp for a Volume could cause a panic.
+
 ## 1.11.0 (May 26, 2020)
 
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.3.0 // indirect
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.11.0
-	github.com/linode/linodego v0.17.0
+	github.com/linode/linodego v0.18.0
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 )

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/linode/linodego v0.17.0 h1:YP6ItAMRCW46leDJaHK1qlIR6hBhuZ+wRqIWxn67/Ag=
-github.com/linode/linodego v0.17.0/go.mod h1:vlzb2glsL9XrRYTRJ5JrgUoKZ5yfZBe11GYfEB68McY=
+github.com/linode/linodego v0.18.0 h1:w/udLSLov9PVYNYMKEBj4Cu0ZtZlOvBd/+0wD2VU2Gk=
+github.com/linode/linodego v0.18.0/go.mod h1:vlzb2glsL9XrRYTRJ5JrgUoKZ5yfZBe11GYfEB68McY=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=

--- a/linode/linode_instance_helpers.go
+++ b/linode/linode_instance_helpers.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/linode/linodego"
@@ -473,13 +474,13 @@ func createInstanceDisk(client linodego.Client, instance linodego.Instance, disk
 		}
 	}
 
+	createTime := time.Now()
 	instanceDisk, err := client.CreateInstanceDisk(context.Background(), instance.ID, diskOpts)
-
 	if err != nil {
 		return nil, fmt.Errorf("Error creating Linode instance %d disk: %s", instance.ID, err)
 	}
 
-	_, err = client.WaitForEventFinished(context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionDiskCreate, instanceDisk.Created, int(d.Timeout(schema.TimeoutCreate).Seconds()))
+	_, err = client.WaitForEventFinished(context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionDiskCreate, createTime, int(d.Timeout(schema.TimeoutCreate).Seconds()))
 	if err != nil {
 		return nil, fmt.Errorf("Error waiting for Linode instance %d disk: %s", instanceDisk.ID, err)
 	}
@@ -757,12 +758,14 @@ func changeInstanceDiskSize(client *linodego.Client, instance linodego.Instance,
 	if _, err := client.WaitForInstanceStatus(context.Background(), instance.ID, linodego.InstanceOffline, int(d.Timeout(schema.TimeoutUpdate).Seconds())); err != nil {
 		return fmt.Errorf("Error waiting for Instance %d to go offline: %s", instance.ID, err)
 	}
+
+	updateTime := time.Now()
 	if err := client.ResizeInstanceDisk(context.Background(), instance.ID, disk.ID, targetSize); err != nil {
 		return fmt.Errorf("Error resizing disk %d for Instance %d: %s", disk.ID, instance.ID, err)
 	}
 
 	// Wait for the disk resize operation to complete, and boot instance.
-	_, err := client.WaitForEventFinished(context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionDiskResize, disk.Updated, int(d.Timeout(schema.TimeoutUpdate).Seconds()))
+	_, err := client.WaitForEventFinished(context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionDiskResize, updateTime, int(d.Timeout(schema.TimeoutUpdate).Seconds()))
 	if err != nil {
 		return fmt.Errorf("Error waiting for resize of Instance %d Disk %d: %s", instance.ID, disk.ID, err)
 	}

--- a/vendor/github.com/linode/linodego/instance_disks.go
+++ b/vendor/github.com/linode/linodego/instance_disks.go
@@ -16,8 +16,8 @@ type InstanceDisk struct {
 	Status     DiskStatus     `json:"status"`
 	Size       int            `json:"size"`
 	Filesystem DiskFilesystem `json:"filesystem"`
-	Created    time.Time      `json:"-"`
-	Updated    time.Time      `json:"-"`
+	Created    *time.Time     `json:"-"`
+	Updated    *time.Time     `json:"-"`
 }
 
 // DiskFilesystem constants start with Filesystem and include Linode API Filesystems
@@ -112,12 +112,8 @@ func (i *InstanceDisk) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	if p.Created != nil {
-		i.Created = time.Time(*p.Created)
-	}
-	if p.Updated != nil {
-		i.Updated = time.Time(*p.Updated)
-	}
+	i.Created = (*time.Time)(p.Created)
+	i.Updated = (*time.Time)(p.Updated)
 
 	return nil
 }

--- a/vendor/github.com/linode/linodego/volumes.go
+++ b/vendor/github.com/linode/linodego/volumes.go
@@ -36,8 +36,8 @@ type Volume struct {
 	LinodeID       *int         `json:"linode_id"`
 	FilesystemPath string       `json:"filesystem_path"`
 	Tags           []string     `json:"tags"`
-	Created        time.Time    `json:"-"`
-	Updated        time.Time    `json:"-"`
+	Created        *time.Time   `json:"-"`
+	Updated        *time.Time   `json:"-"`
 }
 
 // VolumeCreateOptions fields are those accepted by CreateVolume
@@ -88,8 +88,8 @@ func (v *Volume) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	v.Created = time.Time(*p.Created)
-	v.Updated = time.Time(*p.Updated)
+	v.Created = (*time.Time)(p.Created)
+	v.Updated = (*time.Time)(p.Updated)
 
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -423,7 +423,7 @@ github.com/kisielk/gotool
 github.com/kisielk/gotool/internal/load
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/linode/linodego v0.17.0
+# github.com/linode/linodego v0.18.0
 github.com/linode/linodego
 github.com/linode/linodego/internal/duration
 github.com/linode/linodego/internal/kubernetes


### PR DESCRIPTION
Brings in a bugfix (linode/linodego#150) that fixes #152.