### PR TITLE
fix linode_domain_record name in docs

### DIFF
--- a/website/docs/r/domain_record.html.md
+++ b/website/docs/r/domain_record.html.md
@@ -6,7 +6,7 @@ description: |-
   Manages a Linode Domain Record.
 ---
 
-# linode\_domain
+# linode\_domain\_record
 
 Provides a Linode Domain Record resource.  This can be used to create, modify, and delete Linodes Domain Records.
 For more information, see [DNS Manager](https://www.linode.com/docs/platform/manager/dns-manager/) and the [Linode APIv4 docs](https://developers.linode.com/api/v4#operation/createDomainRecord).


### PR DESCRIPTION
On the doc page for [`linode_domain_record`](https://www.terraform.io/docs/providers/linode/r/domain_record.html), the heading is just `linode_domain` instead of `linode_domain_record`. Looks like it might have been initially copied from [`linode_domain`](https://www.terraform.io/docs/providers/linode/r/domain.html). This PR simply changes the heading to `linode_domain_record` - I don't see any other cases on this page.